### PR TITLE
Fix DistanceMetric import to sklearn.metrics

### DIFF
--- a/STdGCN/adjacency_matrix.py
+++ b/STdGCN/adjacency_matrix.py
@@ -3,9 +3,9 @@ import numpy as np
 import pandas as pd
 import scanpy as sc
 import scipy.sparse as sp
-from sklearn.neighbors import KDTree, DistanceMetric
+from sklearn.neighbors import KDTree, NearestNeighbors
+from sklearn.metrics import DistanceMetric
 from sklearn.metrics.pairwise import cosine_similarity
-from sklearn.neighbors import NearestNeighbors
 
 
 


### PR DESCRIPTION
## Summary
- Use `sklearn.metrics.DistanceMetric` instead of deprecated import from `sklearn.neighbors`

## Testing
- `python -m py_compile STdGCN/adjacency_matrix.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d37410494832885e9c1ed4eee05a9