### PR TITLE
refactor: remove multiprocessing

### DIFF
--- a/STdGCN/GCN.py
+++ b/STdGCN/GCN.py
@@ -4,7 +4,7 @@ import numpy as np
 from torch.autograd import Variable
 import math
 import time
-import multiprocessing
+import os
 from torch.nn.parameter import Parameter
 from torch.nn.modules.module import Module
 import torch.nn.functional as F
@@ -174,8 +174,9 @@ def conGCN_train(model,
             print('Use CPU as device.')
     
     if cpu_num == -1:
-        cores = multiprocessing.cpu_count()
-        torch.set_num_threads(cores)
+        cores = os.cpu_count()
+        if cores is not None:
+            torch.set_num_threads(cores)
     else:
         torch.set_num_threads(cpu_num)
     

--- a/STdGCN/autoencoder.py
+++ b/STdGCN/autoencoder.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import time
 import scanpy as sc
-import multiprocessing
+import os
 
 
 
@@ -38,8 +38,9 @@ class autoencoder(nn.Module):
 def auto_train(model, epoch_n, loss_fn, optimizer, data, cpu_num=-1, device='GPU'):
     
     if cpu_num == -1:
-        cores = multiprocessing.cpu_count()
-        torch.set_num_threads(cores)
+        cores = os.cpu_count()
+        if cores is not None:
+            torch.set_num_threads(cores)
     else:
         torch.set_num_threads(cpu_num)
     

--- a/STdGCN/utils.py
+++ b/STdGCN/utils.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import scanpy as sc
 import anndata
-import multiprocessing
 from tqdm.notebook import tqdm
 import random
 from sklearn.decomposition import NMF
@@ -175,14 +174,17 @@ def pseudo_spot_generation(sc_exp,
                           ):
     
     cell_type_num = len(sc_exp.obs['cell_type'].unique())
-    
-    cores = multiprocessing.cpu_count()
-    if n_jobs == -1:
-        pool = multiprocessing.Pool(processes=cores)
-    else:
-        pool = multiprocessing.Pool(processes=n_jobs)
-    args = [(sc_exp, min_cell_number_in_spot, max_cell_number_in_spot, max_cell_types_in_spot, generation_method) for i in range(spot_num)]
-    generated_spots = pool.starmap(generate_a_spot, tqdm(args, desc='Generating pseudo-spots'))
+
+    generated_spots = [
+        generate_a_spot(
+            sc_exp,
+            min_cell_number_in_spot,
+            max_cell_number_in_spot,
+            max_cell_types_in_spot,
+            generation_method,
+        )
+        for _ in tqdm(range(spot_num), desc='Generating pseudo-spots')
+    ]
     
     pseudo_spots = []
     pseudo_spots_table = np.zeros((spot_num, sc_exp.shape[1]), dtype=float)


### PR DESCRIPTION
## Summary
- drop multiprocessing import in model and training utilities
- use os.cpu_count for thread control
- generate pseudo-spots sequentially instead of via multiprocessing

## Testing
- `python -m py_compile STdGCN/GCN.py STdGCN/autoencoder.py STdGCN/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d3a9e74388328a594b67e20a8dcb6